### PR TITLE
PR: Feat matches and results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,6 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<!-- Dependencias para pruebas unitarias e integración -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<!-- Para Spring Security-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -178,9 +172,19 @@
 					<target>${java.version}</target>
 					<annotationProcessorPaths>
 						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>0.2.0</version>
+						</path>
+						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<version>1.18.30</version>
+							<version>1.18.36</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/equipo2/bytestournament/DTO/MatchDTO.java
+++ b/src/main/java/com/equipo2/bytestournament/DTO/MatchDTO.java
@@ -22,21 +22,20 @@ import jakarta.validation.constraints.NotNull;
  * ni las entidades del modelo de datos.
  */
 public class MatchDTO {
-    @NotNull
     @Schema(description = "Identificador único del partido", example = "100", required = true)
     private Long id;
 
     @NotNull
     @Schema(description = "ID del torneo", example = "1", required = true)
-    private Long tournamentId;
+    private Long tournament;
 
     @NotNull
     @Schema(description = "Jugador 1")
-    private User player1;
+    private Long player1;
 
     @NotNull
     @Schema(description = "Jugador 2")
-    private User player2;
+    private Long player2;
 
     @NotNull
     @Schema(description = "Resultado del partido")

--- a/src/main/java/com/equipo2/bytestournament/DTO/MatchDTO.java
+++ b/src/main/java/com/equipo2/bytestournament/DTO/MatchDTO.java
@@ -1,19 +1,18 @@
 package com.equipo2.bytestournament.DTO;
 
 import com.equipo2.bytestournament.enums.Result;
-import com.equipo2.bytestournament.model.User;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Builder;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 
-@Getter
-@Setter
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Schema(description = "DTO para partidas o encuentros")
 /**
  *  MatchDTO es una clase que se utiliza para transportar datos entre diferentes capas de una aplicación,

--- a/src/main/java/com/equipo2/bytestournament/DTO/MessageDTO.java
+++ b/src/main/java/com/equipo2/bytestournament/DTO/MessageDTO.java
@@ -22,7 +22,6 @@ import lombok.Setter;
  *  ni las entidades del modelo de datos.
  */
 public class MessageDTO {
-    @NotNull
     @Schema(description = "Identificador único del mensaje", example = "1")
     private Long id;
      

--- a/src/main/java/com/equipo2/bytestournament/DTO/MessageDTO.java
+++ b/src/main/java/com/equipo2/bytestournament/DTO/MessageDTO.java
@@ -1,19 +1,18 @@
 package com.equipo2.bytestournament.DTO;
 
 import java.time.LocalDateTime;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank; 
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Builder;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Schema(description = "DTO para mensajes en el sistema")
 /**
  *  MessageDTO es una clase que se utiliza para transportar datos entre diferentes capas de una aplicación,

--- a/src/main/java/com/equipo2/bytestournament/DTO/TournamentDTO.java
+++ b/src/main/java/com/equipo2/bytestournament/DTO/TournamentDTO.java
@@ -1,23 +1,21 @@
 package com.equipo2.bytestournament.DTO;
 
 import com.equipo2.bytestournament.enums.Status;
-
 import com.equipo2.bytestournament.model.Match;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Builder;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 import java.util.ArrayList;
 import java.util.List;
 
-@Getter
-@Setter
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Schema(description = "DTO para torneos")
 /**
  *  TournamentDTO es una clase que se utiliza para transportar datos entre diferentes capas de una aplicación,
@@ -43,7 +41,7 @@ public class TournamentDTO {
 
     @NotNull
     @Schema(description = "Número de rondas del torneo", example = "3")
-    private Integer rounds;
+    private Integer rounds = 0;
 
     @NotNull
     @Schema(description = "Número máximo de rondas del torneo", example = "5")

--- a/src/main/java/com/equipo2/bytestournament/DTO/TournamentDTO.java
+++ b/src/main/java/com/equipo2/bytestournament/DTO/TournamentDTO.java
@@ -2,6 +2,7 @@ package com.equipo2.bytestournament.DTO;
 
 import com.equipo2.bytestournament.enums.Status;
 
+import com.equipo2.bytestournament.model.Match;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,6 +10,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -22,8 +26,6 @@ import lombok.Setter;
  *  ni las entidades del modelo de datos.
  */
 public class TournamentDTO {
-
-    @NotNull
     @Schema(description = "Identificador único del torneo", example = "1", required = true)
     private Long id;
 
@@ -38,4 +40,18 @@ public class TournamentDTO {
     @NotNull
     @Schema(description = "Estado del torneo", example = "EN_CURSO")
     private Status status;
+
+    @NotNull
+    @Schema(description = "Número de rondas del torneo", example = "3")
+    private Integer rounds;
+
+    @NotNull
+    @Schema(description = "Número máximo de rondas del torneo", example = "5")
+    private Integer maxRounds;
+
+    @Schema(description = "Lista de partidos asociados al torneo")
+    private List<Match> matches = new ArrayList<>();
+
+    @Schema(description = "Lista de jugadores que participan en el torneo")
+    private List<Long> players = new ArrayList<>();
 }

--- a/src/main/java/com/equipo2/bytestournament/DTO/UserDTO.java
+++ b/src/main/java/com/equipo2/bytestournament/DTO/UserDTO.java
@@ -1,19 +1,18 @@
 package com.equipo2.bytestournament.DTO;
 
+import java.util.List;
+import java.util.Set;
 import com.equipo2.bytestournament.enums.Rank;
 import com.equipo2.bytestournament.enums.Role;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Schema(description = "DTO para usuarios")
@@ -25,21 +24,19 @@ import lombok.Setter;
  *  ni las entidades del modelo de datos.
  */
 public class UserDTO {
-
-    @NotNull
     @Schema(description = "Identificador único del usuario", example = "1", required = true)
     private Long id;
 
     @NotBlank
     @Schema(description = "Nombre de usuario", example = "usuario123")
     private String username;
-
+    
     @NotBlank
     @Schema(description = "Correo electrónico", example = "usuario@gmail.com")
     private String email;
 
     @NotBlank
-    @Schema(description = "Contraseña", example = "password123")
+    @Schema(description = "Contraseña del usuario", example = "password123")
     private String password;
 
     @NotNull
@@ -53,4 +50,13 @@ public class UserDTO {
     @NotNull
     @Schema(description = "Puntos del usuario", example = "1500")
     private Integer points;
+
+    @Schema(description = "Lista de IDs de partidas en las que el usuario ha participado")
+    private List<Long> matches;
+
+    @Schema(description = "Lista de IDs de torneos en los que el usuario ha participado")
+    private List<Long> tournaments;
+
+    @Schema(description = "Lista de privilegios de autoridad del usuario")
+    private Set<String> authorityPrivilegies;
 }

--- a/src/main/java/com/equipo2/bytestournament/DTO/UserDTO.java
+++ b/src/main/java/com/equipo2/bytestournament/DTO/UserDTO.java
@@ -1,5 +1,7 @@
 package com.equipo2.bytestournament.DTO;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import com.equipo2.bytestournament.enums.Rank;
@@ -15,8 +17,8 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Schema(description = "DTO para usuarios")
 @Builder
+@Schema(description = "DTO para usuarios")
 /**
  *  UserDTO es una clase que se utiliza para transportar datos entre diferentes capas de una aplicación,
  *  especialmente entre el backend y el frontend o entre servicios.
@@ -37,7 +39,7 @@ public class UserDTO {
 
     @NotBlank
     @Schema(description = "Contraseña del usuario", example = "password123")
-    private String password;
+    private String password = "hidden"; // Se oculta la contraseña en la documentación
 
     @NotNull
     @Schema(description = "Rol del usuario", example = "ADMIN")
@@ -52,11 +54,11 @@ public class UserDTO {
     private Integer points;
 
     @Schema(description = "Lista de IDs de partidas en las que el usuario ha participado")
-    private List<Long> matches;
+    private List<Long> matches = new ArrayList<>();
 
     @Schema(description = "Lista de IDs de torneos en los que el usuario ha participado")
-    private List<Long> tournaments;
+    private List<Long> tournaments = new ArrayList<>();
 
     @Schema(description = "Lista de privilegios de autoridad del usuario")
-    private Set<String> authorityPrivilegies;
+    private Set<String> authorityPrivilegies = new HashSet<>();
 }

--- a/src/main/java/com/equipo2/bytestournament/contoller/MatchController.java
+++ b/src/main/java/com/equipo2/bytestournament/contoller/MatchController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
 
-
 @RestController
 @RequestMapping("/api/matches")
 public class MatchController {

--- a/src/main/java/com/equipo2/bytestournament/contoller/MatchController.java
+++ b/src/main/java/com/equipo2/bytestournament/contoller/MatchController.java
@@ -1,5 +1,52 @@
 package com.equipo2.bytestournament.contoller;
 
+import com.equipo2.bytestournament.DTO.MatchDTO;
+import com.equipo2.bytestournament.annotations.SwaggerApiResponses;
+import com.equipo2.bytestournament.service.MatchService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+@RestController
+@RequestMapping("/api/matches")
 public class MatchController {
+    
+    private final MatchService matchService;
+    private final Logger logger = LoggerFactory.getLogger(MatchController.class);
+
+    public MatchController(MatchService matchService){
+        this.matchService = matchService;
+    }
+
+    @SwaggerApiResponses
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
+    @PostMapping("/generate/{tournamentId}")
+    public List<MatchDTO> generateMatches(@PathVariable Long tournamentId) {
+        // Se genera un un nuevo match para un torneo especifico
+        logger.info("POST /api/matches/generate/{} - Generating matches for tournament ID: {}", tournamentId, tournamentId);
+        return matchService.generateMatches(tournamentId);
+    }
+    
+    @SwaggerApiResponses
+    @GetMapping("/{id}")
+    public MatchDTO checkMatch(@PathVariable Long id) {
+        // Se comprueba un match por su ID
+        logger.info("GET /api/matches/{} - Checking match with ID: {}", id, id);
+        return matchService.checkMatch(id);
+    }
+
+    @SwaggerApiResponses
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
+    @PutMapping("/{id}/result")
+    public MatchDTO updateMatchResult(@PathVariable Long id, @RequestBody MatchDTO macthDTO) {
+        logger.info("PUT /api/matches/{}/result - Updating result for match ID: {}", id, id);
+        return matchService.updateMatchResult(id, macthDTO);
+    }
 
 }

--- a/src/main/java/com/equipo2/bytestournament/contoller/TournamentController.java
+++ b/src/main/java/com/equipo2/bytestournament/contoller/TournamentController.java
@@ -1,0 +1,48 @@
+package com.equipo2.bytestournament.contoller;
+
+import org.springframework.web.bind.annotation.RestController;
+import com.equipo2.bytestournament.DTO.TournamentDTO;
+import com.equipo2.bytestournament.annotations.SwaggerApiResponses;
+import com.equipo2.bytestournament.service.TournamentService;
+import com.equipo2.bytestournament.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@RestController
+@RequestMapping("/api/tournaments")
+public class TournamentController {
+    private final TournamentService tournamentService;
+    private final Logger logger = LoggerFactory.getLogger(UserService.class);
+
+    public TournamentController(TournamentService tournamentService) {
+        this.tournamentService = tournamentService;
+    }
+    
+    @SwaggerApiResponses
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
+    @PostMapping
+    public TournamentDTO create(@RequestBody TournamentDTO tournamentDTO) {
+        // Creación de un torneo
+        logger.info("POST /api/tournaments - Creating tournament: {}", tournamentDTO);
+        return tournamentService.createTournament(tournamentDTO);
+    }
+    
+    @SwaggerApiResponses
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
+    @PostMapping("/players")
+    public ResponseEntity<TournamentDTO> joinTournament(@RequestParam Long tournamentId, @RequestParam String userName) {
+        // El usuario actual que está autenticado se une al torneo
+        logger.info("POST /api/tournaments/{}/players/{} - User {} joining tournament {}", tournamentId, userName, userName, tournamentId);
+        TournamentDTO tournament = tournamentService.addPlayerToTournament(tournamentId, userName);
+        return ResponseEntity.ok(tournament);
+    }
+}

--- a/src/main/java/com/equipo2/bytestournament/contoller/TournamentController.java
+++ b/src/main/java/com/equipo2/bytestournament/contoller/TournamentController.java
@@ -9,13 +9,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.GetMapping;
-
 
 @RestController
 @RequestMapping("/api/tournaments")

--- a/src/main/java/com/equipo2/bytestournament/contoller/UserController.java
+++ b/src/main/java/com/equipo2/bytestournament/contoller/UserController.java
@@ -5,11 +5,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.equipo2.bytestournament.DTO.UserDTO;
 import com.equipo2.bytestournament.annotations.SwaggerApiResponses;
 import com.equipo2.bytestournament.service.UserService;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 
@@ -19,6 +20,7 @@ import org.springframework.security.core.Authentication;
 public class UserController {
     
     private final UserService userService;
+    private final Logger logger = LoggerFactory.getLogger(UserController.class);
 
     public UserController(UserService customUserDetailsService){
         this.userService=customUserDetailsService;
@@ -28,12 +30,14 @@ public class UserController {
     @SwaggerApiResponses
     @PostMapping("/auth/register")
     public String registerUser(@RequestBody UserDTO entity) {
+        logger.info("POST /auth/register with email: " + entity.getEmail());
         return userService.registerUser(entity);
     }
 
     @SwaggerApiResponses
     @GetMapping("/auth/login")
     public String userLogin(@RequestBody UserDTO entity) {
+        logger.info("GET /auth/login with email: " + entity.getEmail());
         return userService.userLogin(entity);
     }
 
@@ -41,12 +45,14 @@ public class UserController {
     @GetMapping("/user/me")
     @PreAuthorize("hasAnyAuthority('PLAYER', 'ADMIN')")
     public UserDTO personalData(Authentication authentication) {
+        logger.info("GET /user/me for user: " + authentication.getName());
         return userService.profileData(authentication);
     }
 
     @SwaggerApiResponses
     @GetMapping("/user/{id}")
     public UserDTO profileUser(@PathVariable Long id) {
+        logger.info("GET /user/{id} for user ID: " + id);
         return userService.profileUser(id);
     }
 }

--- a/src/main/java/com/equipo2/bytestournament/enums/ApiResponse.java
+++ b/src/main/java/com/equipo2/bytestournament/enums/ApiResponse.java
@@ -9,24 +9,14 @@ import org.springframework.http.HttpStatus;
  * y constructores con todos los argumentos
  */
 public enum ApiResponse {
-    // User-related responses
-    USER_DELETE_FAILED(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Eliminación de Usuario Fallida",
-            "No se pudo eliminar el usuario debido a un error interno."),
-    USER_NOT_FOUND(
-            HttpStatus.NOT_FOUND,
-            "Usuario No Encontrado",
-            "El usuario solicitado no existe en el sistema."),
-    USER_ALREADY_EXISTS(
-            HttpStatus.CONFLICT,
-            "Usuario Existente",
-            "El usuario ya existe con el identificador proporcionado."),
     AUTHENTICATION_FAILED(
             HttpStatus.UNAUTHORIZED,
             "Autenticación Fallida",
             "Credenciales Inválidas"),
-    // Other responses
+    NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "Recurso no encontrado",
+            "El recuros solicitado no existe en el sistema."),
     BAD_REQUEST(
             HttpStatus.BAD_REQUEST,
             "Petición Incorrecta",

--- a/src/main/java/com/equipo2/bytestournament/enums/Status.java
+++ b/src/main/java/com/equipo2/bytestournament/enums/Status.java
@@ -8,9 +8,7 @@ package com.equipo2.bytestournament.enums;
  */
 
 public enum Status {
-
-    CREATED,
+    PENDING,
     IN_PROGRESS,
     FINISHED
-
 }

--- a/src/main/java/com/equipo2/bytestournament/mapper/MatchMapper.java
+++ b/src/main/java/com/equipo2/bytestournament/mapper/MatchMapper.java
@@ -1,21 +1,36 @@
 package com.equipo2.bytestournament.mapper;
 
 import com.equipo2.bytestournament.DTO.MatchDTO;
+import com.equipo2.bytestournament.mapper.helper.MatchMapperHelper;
 import com.equipo2.bytestournament.model.Match;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
 import java.util.List;
 /**
  * Mapper que convierte la entidad Match a DTO y la DTO a entidad
  *
  * @author Christian Escalas
  */
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {MatchMapperHelper.class})
 public interface MatchMapper {
-    MatchDTO matchToMatchDTO(Match match);
-
+    @Mapping(source = "tournament", target = "tournament")
+    @Mapping(source = "player1", target = "player1")
+    @Mapping(source = "player2", target = "player2")
     Match matchDtoToMatch(MatchDTO matchDTO);
 
-    List<MatchDTO> matchToMatchDtos(List<Match> matches);
-    
-    List<Match> matchDtosToMatches(List<MatchDTO> matchDTOs);
+    @Mapping(source = "tournament", target = "tournament")
+    @Mapping(source = "player1", target = "player1")
+    @Mapping(source = "player2", target = "player2")
+    List<Match> matchDTOListToMatchList(List<MatchDTO> matchDTOs);
+
+    @Mapping(source = "tournament", target = "tournament")
+    @Mapping(source = "player1", target = "player1")
+    @Mapping(source = "player2", target = "player2")
+    List<MatchDTO> matchListToMatchDTOList(List<Match> matches);
+
+    @Mapping(source = "tournament", target = "tournament")
+    @Mapping(source = "player1", target = "player1")
+    @Mapping(source = "player2", target = "player2")
+    MatchDTO matchToMatchDTO(Match match);
 }

--- a/src/main/java/com/equipo2/bytestournament/mapper/TournamentMapper.java
+++ b/src/main/java/com/equipo2/bytestournament/mapper/TournamentMapper.java
@@ -1,22 +1,23 @@
 package com.equipo2.bytestournament.mapper;
 
 import com.equipo2.bytestournament.DTO.TournamentDTO;
+import com.equipo2.bytestournament.mapper.helper.TournamentMapperHelper;
 import com.equipo2.bytestournament.model.Tournament;
 import org.mapstruct.Mapper;
-import java.util.List;
+import org.mapstruct.Mapping;
 
 /**
  * Mapper que convierte la entidad Tournament a DTO y la DTO a entidad
  *
  * @author Christian Escalas
  */
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {TournamentMapperHelper.class})
 public interface TournamentMapper {
+    @Mapping(target = "matches", source = "matches")
+    @Mapping(target = "players", source = "players")
     TournamentDTO tournamentToTournamentDTO(Tournament tournament);
 
+    @Mapping(target = "matches", source = "matches")
+    @Mapping(target = "players", source = "players")
     Tournament tournamentDtoToTournament(TournamentDTO tournamentDTO);
-
-    List<TournamentDTO> tournamentToTournamentDtos(List<Tournament> tournaments);
-
-    List<Tournament> tournamentDtosToTournaments(List<TournamentDTO> tournamentDTOS);
 }

--- a/src/main/java/com/equipo2/bytestournament/mapper/UserMapper.java
+++ b/src/main/java/com/equipo2/bytestournament/mapper/UserMapper.java
@@ -1,32 +1,36 @@
 package com.equipo2.bytestournament.mapper;
 
 import com.equipo2.bytestournament.DTO.UserDTO;
+import com.equipo2.bytestournament.mapper.helper.UserMapperHelper;
 import com.equipo2.bytestournament.model.User;
-import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
-@Component
-public class UserMapper {
+@Mapper(componentModel = "spring", uses = {UserMapperHelper.class})
+public interface UserMapper {
+    public final Logger logger = LoggerFactory.getLogger(UserMapper.class);
+
+    // User -> UserDTO
+    @Mapping(source = "tournaments", target = "tournaments")
+    @Mapping(source = ".", target = "matches") // Combina las listas de cuando a sido palyer1 y player2
+    @Mapping(target = "authorityPrivilegies", source = "authorityPrivilegies")
+    @Mapping(target = "password", ignore = true) // Ignoramos la contraseña para que no se mapee desde el DTO
+    UserDTO userToUserDTO(User user);
     
-    public UserDTO userToUserDTO(User user) {
-       return UserDTO.builder()
-                .id(user.getId())
-                .username(user.getUsername())
-                .email(user.getEmail())
-                .password(user.getPassword())
-                .role(user.getRole())
-                .rank(user.getRank())
-                .points(user.getPoints())
-                .build();
-    }
-    
-    public User userDTOToUser(UserDTO dto) {
-       return User.builder()
-                .username(dto.getUsername())
-                .email(dto.getEmail())
-                .password(dto.getPassword())
-                .role(dto.getRole())
-                .rank(dto.getRank())
-                .points(dto.getPoints())
-                .build();
+    // UserDTO -> User
+    // Como en el UserDTO tenemos todos los matches sin diferenciar entre si es player 1 o dos, no podemos agreagr users desde userDto a user
+    @Mapping(target = "matchesAsPlayer1", ignore = true)
+    @Mapping(target = "matchesAsPlayer2", ignore = true)
+    @Mapping(target = "tournaments", source = "tournaments")
+    @Mapping(target = "authorityPrivilegies", source = "authorityPrivilegies")
+    User userDTOToUser(UserDTO userDTO);
+
+    @AfterMapping
+    default void logAfterUserMapping(User user, @MappingTarget UserDTO userDTO) {
+        logger.info("Finalizado mapeo de User a UserDTO para usuario: " + userDTO.getUsername());
     }
 }

--- a/src/main/java/com/equipo2/bytestournament/mapper/helper/MatchMapperHelper.java
+++ b/src/main/java/com/equipo2/bytestournament/mapper/helper/MatchMapperHelper.java
@@ -1,0 +1,58 @@
+package com.equipo2.bytestournament.mapper.helper;
+
+import com.equipo2.bytestournament.model.Tournament;
+import com.equipo2.bytestournament.model.User;
+import com.equipo2.bytestournament.repository.UserRepository;
+import com.equipo2.bytestournament.repository.TournamentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MatchMapperHelper {
+
+    private final UserRepository userRepository;
+    private final TournamentRepository tournamentRepository;
+    private final Logger logger = LoggerFactory.getLogger(MatchMapperHelper.class.getName());
+
+    public MatchMapperHelper(UserRepository userRepository, TournamentRepository tournamentRepository) {
+        this.userRepository = userRepository;
+        this.tournamentRepository = tournamentRepository;
+    }
+
+    public Tournament fromTournamentId(Long id) {
+        try {
+            return id == null ? null : tournamentRepository.findById(id).orElse(null);
+        } catch (Exception e) {
+            logger.error("Error al buscar el torneo con ID: " + id, e);
+            return null; // Retorna null en caso de error
+        }
+    }
+
+    public Long toTournamentId(Tournament tournament) {
+        try {
+            return tournament == null ? null : tournament.getId();
+        } catch (Exception e) {
+            logger.error("Error al obtener el ID del torneo: " + tournament, e);
+            return null;
+        }
+    }
+
+    public User fromId(Long id) {
+        try {
+            return id == null ? null : userRepository.findById(id).orElse(null);
+        } catch (Exception e) {
+            logger.error("Error al buscar el usuario con ID: " + id, e);
+            return null; // Retorna null en caso de error
+        }
+    }
+
+    public Long toId(User user) {
+        try {
+            return user == null ? null : user.getId();
+        } catch (Exception e) {
+            logger.error("Error al obtener el ID del usuario: " + user, e);
+            return null; // Retorna null en caso de error
+        }
+    }
+}

--- a/src/main/java/com/equipo2/bytestournament/mapper/helper/TournamentMapperHelper.java
+++ b/src/main/java/com/equipo2/bytestournament/mapper/helper/TournamentMapperHelper.java
@@ -1,0 +1,116 @@
+package com.equipo2.bytestournament.mapper.helper;
+
+import com.equipo2.bytestournament.model.Match;
+import com.equipo2.bytestournament.model.User;
+import com.equipo2.bytestournament.repository.MatchRepository;
+import com.equipo2.bytestournament.repository.UserRepository;
+import org.mapstruct.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Helper para asistir al TournamentMapper con conversiones complejas
+ * entre entidades y DTOs.
+ */
+@Component
+public class TournamentMapperHelper {
+
+    private final UserRepository userRepository;
+    private final MatchRepository matchRepository;
+    private final Logger logger = LoggerFactory.getLogger(TournamentMapperHelper.class);
+
+    public TournamentMapperHelper(UserRepository userRepository, MatchRepository matchRepository) {
+        this.userRepository = userRepository;
+        this.matchRepository = matchRepository;
+    }
+
+    /**
+     * Convierte una lista de partidas a una lista de IDs de partidas.
+     * 
+     * @param matches Lista de partidas
+     * @return Lista de IDs de partidas
+     */
+    public List<Long> matchesToIds(List<Match> matches) {
+        try {
+            if (matches == null) {
+                return null;
+            }
+            
+            return matches.stream()
+                    .map(Match::getId)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.error("Error al convertir la lista de partidas a IDs", e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Convierte una lista de IDs de partidas a una lista de partidas.
+     * 
+     * @param matchIds Lista de IDs de partidas
+     * @return Lista de partidas
+     */
+    public List<Match> idsToMatches(List<Long> matchIds) {
+        try {
+            if (matchIds == null) {
+                return null;
+            }
+            
+            return matchIds.stream()
+                    .map(id -> matchRepository.findById(id).orElse(null))
+                    .filter(match -> match != null)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.error("Error al convertir la lista de IDs de partidas a objetos Match", e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Convierte una lista de jugadores a una lista de IDs de usuarios.
+     * 
+     * @param players Lista de jugadores (usuarios)
+     * @return Lista de IDs de usuarios
+     */
+    public List<Long> playersToIds(List<User> players) {
+        try {
+            if (players == null) {
+                return null;
+            }
+            
+            return players.stream()
+                    .map(User::getId)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.error("Error al convertir la lista de jugadores a IDs", e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Convierte una lista de IDs de usuarios a una lista de jugadores (usuarios).
+     * 
+     * @param playerIds Lista de IDs de usuarios
+     * @return Lista de jugadores (usuarios)
+     */
+    public List<User> idsToPlayers(List<Long> playerIds) {
+        try {
+            if (playerIds == null) {
+                return null;
+            }
+            
+            return playerIds.stream()
+                    .map(id -> userRepository.findById(id).orElse(null))
+                    .filter(user -> user != null)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.error("Error al convertir la lista de IDs de usuarios a objetos User", e);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/equipo2/bytestournament/mapper/helper/UserMapperHelper.java
+++ b/src/main/java/com/equipo2/bytestournament/mapper/helper/UserMapperHelper.java
@@ -1,0 +1,137 @@
+package com.equipo2.bytestournament.mapper.helper;
+
+import com.equipo2.bytestournament.enums.AuthorityPrivilegies;
+import com.equipo2.bytestournament.model.Match;
+import com.equipo2.bytestournament.model.Tournament;
+import com.equipo2.bytestournament.model.User;
+import com.equipo2.bytestournament.repository.TournamentRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapperHelper {
+
+    private final TournamentRepository tournamentRepository;
+    public final Logger logger = LoggerFactory.getLogger(UserMapperHelper.class);
+    
+    public UserMapperHelper(TournamentRepository tournamentRepository) {
+        this.tournamentRepository = tournamentRepository;
+    }
+    /**
+     * Combina las listas de partidas donde el usuario es player1 y player2
+     * y las convierte en una única lista de IDs.
+     * 
+     * @param user El usuario con las listas de partidas
+     * @return Lista combinada de IDs de partidas
+     */
+    public List<Long> combineMatchesToIds(User user) {
+        try {
+            List<Match> allMatches = new ArrayList<>();
+            
+            // Añadir partidas donde el usuario es player1
+            if (user.getMatchesAsPlayer1() != null && !user.getMatchesAsPlayer1().isEmpty()) {
+                allMatches.addAll(user.getMatchesAsPlayer1());
+            }
+            
+            // Añadir partidas donde el usuario es player2
+            if (user.getMatchesAsPlayer2() != null && !user.getMatchesAsPlayer2().isEmpty()) {
+                allMatches.addAll(user.getMatchesAsPlayer2());
+            }
+            
+            // Convertir la lista combinada a una lista de IDs
+            return allMatches.stream()
+                    .map(Match::getId)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.error("Error al combinar las partidas del usuario: " + user.getUsername(), e);
+            return new ArrayList<>(); // Retorna una lista vacía en caso de error
+        }
+        
+    }
+    
+    /**
+     * Convierte una lista de torneos en una lista de IDs de torneos.
+     * 
+     * @param tournaments Lista de torneos
+     * @return Lista de IDs de torneos
+     */
+    public List<Long> tournamentsToIds(List<Tournament> tournaments) {
+        try {
+            if (tournaments == null) {
+            return null;
+        }
+        
+        return tournaments.stream()
+                .map(Tournament::getId)
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.error("Error al convertir la lista de torneos a IDs", e);
+            return new ArrayList<>(); // Retorna una lista vacía en caso de error
+        }
+    }
+
+    /**
+     * Convierte una lista de IDs de torneos en una lista de objetos Tournament.
+     * @param tournamentIds
+     * @return
+     */
+    public List<Tournament> idsToTournaments(List<Long> tournamentIds) {
+        try {
+            if (tournamentIds == null) {
+            return null;
+        }
+        
+        return tournamentIds.stream()
+                .map(id -> tournamentRepository.findById(id).orElse(null))
+                .filter(tournament -> tournament != null)
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.error("Error al convertir la lista de IDs de torneos a objetos Tournament", e);
+            return new ArrayList<>(); // Retorna una lista vacía en caso de error
+        }
+    }
+
+    /**
+     * Convierte una lista de privilegios a un conjunto de nombres de privilegios.
+     * Utiliza AuthorityPrivilegies para mapear los IDs a nombres.
+     * 
+     * @param privileges Lista de IDs de privilegios
+     * @return Set de nombres de privilegios
+     */
+    public Set<String> privilegesToNames(Set<AuthorityPrivilegies> privileges) {
+        try {
+            return privileges.stream()
+            .map(Enum::name)  // Usa el método estándar name() de los enums
+            .collect(Collectors.toSet());
+        } catch (Exception e) {
+            logger.error("Error al convertir la lista de privilegios a nombres", e);
+            return Set.of(); // Retorna un conjunto vacío en caso de error
+        }
+        
+    }
+
+    /**
+     * Convierte un conjunto de nombres de privilegios a un conjunto de AuthorityPrivilegies.
+     * Utiliza AuthorityPrivilegies para mapear los nombres a objetos AuthorityPrivilegies.
+     * 
+     * @param privilegeNames
+     * @return
+     */
+    public Set<AuthorityPrivilegies>  namesToPrivileges(Set<String> privilegeNames) {
+        try {
+            return privilegeNames.stream()
+            .map(name -> AuthorityPrivilegies.valueOf(name))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        } catch (Exception e) {
+            logger.error("Error al convertir el conjunto de nombres de privilegios a AuthorityPrivilegies", e);
+            return Set.of(); // Retorna un conjunto vacío en caso de error
+        }
+    }
+}

--- a/src/main/java/com/equipo2/bytestournament/model/Match.java
+++ b/src/main/java/com/equipo2/bytestournament/model/Match.java
@@ -1,6 +1,7 @@
 package com.equipo2.bytestournament.model;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Data;
 import com.equipo2.bytestournament.enums.Result;
 
@@ -12,8 +13,10 @@ import com.equipo2.bytestournament.enums.Result;
  */
 @Data
 @Entity
+@Builder
 @Table(name = "matches") // Ensure the table name is correctly set
 public class Match {
+    public static final Integer UMBRAL = 100;
 
     /**
      * Identificador único de la partida. No debe ser nulo
@@ -24,10 +27,11 @@ public class Match {
     private Long id;
 
     /**
-     * Identificador único del torneo. No debe ser nulo
+     * Identificador único del torneo al que pertenece. No debe ser nulo
      */
-    @Column(name = "tournament_id", nullable = false)
-    private Long tournamentId;
+    @ManyToOne
+    @JoinColumn(name = "tournament_id", referencedColumnName = "id")
+    private Tournament tournament;
 
     /**
      * Jugador 1 que participa en la partida. No debe ser nulo
@@ -62,16 +66,17 @@ public class Match {
     /**
      * Construye un nuevo torneo con nombre, número máximo de jugadores y estado.
      *
-     * @param tournamentId id del torneo al que pertenece la partida.
+     * @param tournament id del torneo al que pertenece la partida.
      * @param player1      Jugador1 que participa en la partida. No puede ser null ni vacío.
      * @param player2      Jugador2 que participa en la partida. No puede ser null ni vacío.
      * @param result       resultado actual de la partida. No puede ser null ni vacío.
      */
-    public Match(Long tournamentId, User player1, User player2, Result result) {
-        this.tournamentId = tournamentId;
+    public Match(Long id, Tournament tournament, User player1, User player2, Result result, Integer round) {
+        this.id = id;
+        this.tournament = tournament;
         this.player1 = player1;
         this.player2 = player2;
         this.result = result;
-        this.round = 1;
+        this.round = round;
     }
 }

--- a/src/main/java/com/equipo2/bytestournament/model/Match.java
+++ b/src/main/java/com/equipo2/bytestournament/model/Match.java
@@ -1,82 +1,57 @@
 package com.equipo2.bytestournament.model;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import com.equipo2.bytestournament.enums.Result;
 
 /**
- * Entidad JPA que representa una partida de un torneo de la aplicación de torneos.
+ * Entidad JPA que representa una partida de un torneo.
  * Contiene el id del torneo, el jugador 1, el jugador 2 y la ronda actual.
- *
  * @author Christian Escalas
  */
 @Data
 @Entity
 @Builder
-@Table(name = "matches") // Ensure the table name is correctly set
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "matches")
 public class Match {
     public static final Integer UMBRAL = 100;
 
     /**
-     * Identificador único de la partida. No debe ser nulo
+     * id: Entidad JPA que representa una partida de un torneo de la aplicación de torneos.
+     * tournament: Contiene el id del torneo, el jugador 1, el jugador 2 y la ronda actual.
+     * player1: Jugador 1 que participa en la partida. No debe ser nulo
+     * player2: Jugador 2 que participa en la partida. No debe ser nulo
+     * result: Resultado de la partida. No debe ser nulo ni vacío.
+     * round: Ronda actual de la partida
+     * @author Christian Escalas
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", updatable = false, nullable = false)
     private Long id;
 
-    /**
-     * Identificador único del torneo al que pertenece. No debe ser nulo
-     */
     @ManyToOne
     @JoinColumn(name = "tournament_id", referencedColumnName = "id")
     private Tournament tournament;
 
-    /**
-     * Jugador 1 que participa en la partida. No debe ser nulo
-     */
     @ManyToOne
     @JoinColumn(name = "player1_id", nullable = false)
     private User player1;
 
-    /**
-     * Jugador 2 que participa en la partida. No debe ser nulo
-     */
     @ManyToOne
     @JoinColumn(name = "player2_id", nullable = false)
     private User player2;
 
-    /**
-     * Resultado de la partida. No debe ser nulo ni vacío.
-     */
     @Enumerated(EnumType.STRING)
     @Column(name = "result")
     private Result result;
 
-    /**
-     * Ronda actual de la partida
-     */
     @Column(name = "round", updatable = true, nullable = false)
     private Integer round;
-
-    public Match() {
-    }
-
-    /**
-     * Construye un nuevo torneo con nombre, número máximo de jugadores y estado.
-     *
-     * @param tournament id del torneo al que pertenece la partida.
-     * @param player1      Jugador1 que participa en la partida. No puede ser null ni vacío.
-     * @param player2      Jugador2 que participa en la partida. No puede ser null ni vacío.
-     * @param result       resultado actual de la partida. No puede ser null ni vacío.
-     */
-    public Match(Long id, Tournament tournament, User player1, User player2, Result result, Integer round) {
-        this.id = id;
-        this.tournament = tournament;
-        this.player1 = player1;
-        this.player2 = player2;
-        this.result = result;
-        this.round = round;
-    }
 }

--- a/src/main/java/com/equipo2/bytestournament/model/Message.java
+++ b/src/main/java/com/equipo2/bytestournament/model/Message.java
@@ -1,79 +1,51 @@
 package com.equipo2.bytestournament.model;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 
 /**
  * Entidad JPA que representa un mensaje en el chat de una partida de la aplicación de torneos.
- * <p>
  * Contiene el id del mensaje, el id del jugador que lo envía, el contenido, la fecha y hora de envío del mensaje, el id de la partidaa y el id del torneo.
  *
  * @author Christian Escalas
  */
 @Data
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "messages")
 public class Message {
-
     /**
-     * Identificador único del mensaje. No debe ser nulo
+     * id: Identificador único del mensaje. No debe ser nulo
+     * senderId: Identificador único del jugador que envía el mensaje. No debe ser nulo
+     * conmtent: Contenido del mensaje enviado. No puede ser nulo.
+     * timestamp: Fecha y hora de envío del mensaje. No puede ser nulo.
+     * Identificador único del torneo. No debe ser nulo
+     * tournamentId: Identificador único del torneo que se genera automaticamente
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", updatable = false, nullable = false)
     private Long id;
 
-    /**
-     * Identificador único del jugador que envía el mensaje. No debe ser nulo
-     */
     @Column(name = "sender_id", updatable = false, nullable = false)
     private Long senderId;
 
-    /**
-     * Contenido del mensaje enviado. No puede ser nulo.
-     */
     @Column(name = "content", updatable = true, nullable = false)
     private String content;
 
-    /**
-     * Fecha y hora de envío del mensaje. No puede ser nulo.
-     */
     @Column(name = "timestamp", updatable = false, nullable = false)
     private LocalDateTime timestamp;
 
-    /**
-     * Identificador único del torneo. No debe ser nulo
-     */
-    // TODO: Relación entre Message y Match
     @Column(name = "match_id", updatable = false, nullable = false)
     private Long matchId;
 
-    /**
-     * Identificador único del torneo que se genera automaticamente
-     */
-    // TODO: Relación entre Message y Tournament
     @Column(name = "tournament_id", updatable = false, nullable = false)
     private Long tournamentId;
-
-    public Message() {
-    }
-
-    /**
-     * Construye un nuevo mensaje con el id del jugador que lo manda, el contenido, la fecha y hora del envío,
-     * el id de la partida y el id del torneo al que pertenece la partida.
-     *
-     * @param senderId     id del jugador que envía el mensaje que participa en la partida. No puede ser null ni vacío.
-     * @param content      contenido del mensaje.
-     * @param timestamp    fecha y hora en la que se envía el mensaje.
-     * @param matchId      id de la partida
-     * @param tournamentId id del torneo al que pertenece la partida
-     */
-    public Message(Long senderId, String content, LocalDateTime timestamp, Long matchId, Long tournamentId) {
-        this.senderId = senderId;
-        this.content = content;
-        this.timestamp = timestamp;
-        this.matchId = matchId;
-        this.tournamentId = tournamentId;
-    }
 }

--- a/src/main/java/com/equipo2/bytestournament/model/Tournament.java
+++ b/src/main/java/com/equipo2/bytestournament/model/Tournament.java
@@ -2,19 +2,26 @@ package com.equipo2.bytestournament.model;
 
 import jakarta.persistence.*;
 import com.equipo2.bytestournament.enums.Status;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Entidad JPA que representa un torneo de la aplicación de torneos.
- * <p>
  * Contiene el nombre del torneo, los jugadores máximos que participan y el estado.
  *
  * @author Christian Escalas
  */
 @Data
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "tournaments")
 public class Tournament {
     /**
@@ -57,21 +64,4 @@ public class Tournament {
             joinColumns = @JoinColumn(name = "tournament_id"),
             inverseJoinColumns = @JoinColumn(name = "user_id"))
     private List<User> players = new ArrayList<>();
-
-    public Tournament() {}
-
-    /**
-     * Construye un nuevo torneo con nombre, número máximo de jugadores y estado.
-     *
-     * @param name       nombre de usuario. No puede ser null ni vacío.
-     * @param maxPlayers cantidad máxima de jugadores participantes .
-     * @param status     estado actual del torneo. No puede ser null ni vacío.
-     */
-    public Tournament(String name, Integer maxPlayers, Status status) {
-        this.name = name;
-        this.maxPlayers = maxPlayers;
-        this.status = status;
-        this.rounds = 0; // Inicializamos las rondas en 0
-        this.maxRounds = 0; // Inicializamos las rondas máximas en 0
-    }
 }

--- a/src/main/java/com/equipo2/bytestournament/model/Tournament.java
+++ b/src/main/java/com/equipo2/bytestournament/model/Tournament.java
@@ -3,7 +3,8 @@ package com.equipo2.bytestournament.model;
 import jakarta.persistence.*;
 import com.equipo2.bytestournament.enums.Status;
 import lombok.Data;
-
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Entidad JPA que representa un torneo de la aplicación de torneos.
@@ -16,33 +17,46 @@ import lombok.Data;
 @Entity
 @Table(name = "tournaments")
 public class Tournament {
-
     /**
-     * Identificador único del torneo que se genera automaticamente
+     * id: Identificador único del torneo que se genera automaticamente
+     * name: Nombre del torneo. Debe ser único y no nulo.
+     * maxPlayers: Cantidad máxima de jugadores que pueden participar en el torneo. No puede ser nulo.
+     * status: Estado asignado al usuario. No debe ser nulo ni vacío.
+     * rounds: Número de ronda actual del torneo.
+     * maxRounds: Número máximo de rondas del torneo.
+     * matchesList: Lista de partidos asociados al torneo.
+     * players: Lista de jugadores que participan en el torneo.
+     * un torneo puede tener múltiples jugadores y un jugador puede participar en múltiples torneos.
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", updatable = false, nullable = false)
     private Long id;
 
-    /**
-     * Nombre del torneo. Debe ser único y no nulo.
-     */
     @Column(name = "name", updatable = true, nullable = false, unique = true)
     private String name;
 
-    /**
-     * Cantidad máxima de jugadores que pueden participar en el torneo. No puede ser nulo.
-     */
     @Column(name = "max_players", updatable = true, nullable = false)
     private Integer maxPlayers;
 
-    /**
-     * Estado asignado al usuario. No debe ser nulo ni vacío.
-     */
     @Enumerated(EnumType.STRING)
     @Column(name = "status", updatable = true, nullable = false)
     private Status status;
+
+    @Column(name = "rounds", updatable = true, nullable = false)
+    private Integer rounds;
+
+    @Column(name = "max_rounds", updatable = true, nullable = false)
+    private Integer maxRounds;
+
+    @OneToMany(mappedBy = "tournament", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Match> matches = new ArrayList<>();
+
+    @ManyToMany(cascade = CascadeType.ALL)
+    @JoinTable(name = "tournament_players",
+            joinColumns = @JoinColumn(name = "tournament_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private List<User> players = new ArrayList<>();
 
     public Tournament() {}
 
@@ -57,5 +71,7 @@ public class Tournament {
         this.name = name;
         this.maxPlayers = maxPlayers;
         this.status = status;
+        this.rounds = 0; // Inicializamos las rondas en 0
+        this.maxRounds = 0; // Inicializamos las rondas máximas en 0
     }
 }

--- a/src/main/java/com/equipo2/bytestournament/model/User.java
+++ b/src/main/java/com/equipo2/bytestournament/model/User.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -14,7 +15,6 @@ import java.util.List;
 import java.util.Set;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
 
 /**
  * Entidad JPA que representa un usuario de la aplicación de torneos.
@@ -24,9 +24,10 @@ import org.springframework.security.core.userdetails.UserDetails;
  */
 @Data
 @Entity
-@Table(name = "users")
 @AllArgsConstructor
+@NoArgsConstructor 
 @Builder
+@Table(name = "users")
 public class User implements UserDetails{
 
     /**
@@ -85,9 +86,9 @@ public class User implements UserDetails{
     @Enumerated(EnumType.STRING)
     private Set<AuthorityPrivilegies> authorityPrivilegies = new HashSet<>();
 
+    // Combina los privilegios del rol con los privilegios adicionales del usuario
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // Combina los privilegios del rol con los privilegios adicionales del usuario
         Set<AuthorityPrivilegies> allPrivilegies = new HashSet<>();
         if (authorityPrivilegies != null) {
             allPrivilegies.addAll(authorityPrivilegies);
@@ -96,26 +97,5 @@ public class User implements UserDetails{
         return allPrivilegies.stream()
                 .map(authority -> (GrantedAuthority) () -> authority.name())
                 .toList();
-    }
-
-    public User() {}
-
-    /**
-     * Construye un nuevo usuario con nombre, email, contraseña, rol y rango es opcional.
-     * Los puntos iniciales se establecen a 0.
-     *
-     * @param username nombre de usuario. No puede ser null ni vacío.
-     * @param email    dirección de email. No puede ser null ni vacío.
-     * @param password contraseña. No puede ser null ni vacío.
-     * @param role     rol del usuario. No puede ser null.
-     * @param rank     ranking o categoría; puede ser null o vacío.
-     */
-    public User(String username, String email, String password, Role role, Rank rank) {
-        this.username = username;
-        this.email = email;
-        this.password = password;
-        this.role = role;
-        this.rank = rank;
-        this.points = 0; 
     }
 }

--- a/src/main/java/com/equipo2/bytestournament/model/User.java
+++ b/src/main/java/com/equipo2/bytestournament/model/User.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -29,56 +30,55 @@ import org.springframework.security.core.userdetails.UserDetails;
 public class User implements UserDetails{
 
     /**
-     * Identificador único del usuario que se genera automaticamente
+     * id: Identificador único del usuario que se genera automaticamenteç
+     * username: Nombre de usuario único y no nulo.
+     * email: Dirección de email del usuario. Debe ser única y no nula.
+     * password: Contraseña del usuario. No debe ser nula ni vacía.
+     * role: Rol asignado al usuario. No debe ser nulo ni vacío.
+     * rank: Categoría del usuario. No puede ser nula
+     * points: Puntos del usuario. Valor no negativo.
+     * matchesAsPlayer1: Lista de partidas en las que el usuario ha participado como jugador 1.
+     * matchesAsPlayer2: Lista de partidas en las que el usuario ha participado como jugador 2.
+     * tournaments: Lista de torneos en los que participa el usuario, un usuario puede participar 
+     * en múltiples torneos y un torneo puede tener múltiples jugadores.
+    * authorityPrivilegies:  Lista de privilegios adicionales asignados al usuario.
+    * Estos privilegios se combinan con los del rol del usuario para determinar sus permisos.
+    * Se almacenan en una tabla separada para permitir una gestión flexible de los privilegios.
+     * Constructor por defecto requerido por JPA.
      */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", updatable = false, nullable = false)
     private Long id;
 
-    /**
-     * Nombre de usuario. Debe ser único y no nulo.
-     */
     @Column(name = "username", updatable = true, nullable = false, unique = true)
     private String username;
 
-    /**
-     * Dirección de email del usuario. Debe ser única y no nula.
-     */
     @Column(name = "email", updatable = true, nullable = false, unique = true)
     private String email;
 
-    /**
-     * Contraseña del usuario. No debe ser nula ni vacía.
-     */
     @Column(name = "password", updatable = true, nullable = false)
     private String password;
 
-    /**
-     * Rol asignado al usuario. No debe ser nulo ni vacío.
-     */
     @Enumerated(EnumType.STRING)
     @Column(name = "role", updatable = true, nullable = false)
     private Role role;
 
-    /**
-     * Categoría del usuario. No puede ser nula
-     */
     @Enumerated(EnumType.STRING)
     @Column(name = "rank", updatable = true, nullable = false)
     private Rank rank;
 
-    /**
-     * Puntos del usuario. Valor no negativo.
-     */
     @Column(name = "points", updatable = true, nullable = false)
     private Integer points;
 
     @OneToMany(mappedBy = "player1")
-    private List<Match> matchesAsPlayer1;
+    private List<Match> matchesAsPlayer1 = new ArrayList<>();
 
     @OneToMany(mappedBy = "player2")
-    private List<Match> matchesAsPlayer2;
+    private List<Match> matchesAsPlayer2 = new ArrayList<>();
+
+    @ManyToMany(mappedBy = "players")
+    private List<Tournament> tournaments = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(name = "user_authority_privilegies", joinColumns = @JoinColumn(name = "user_id"))
@@ -98,11 +98,7 @@ public class User implements UserDetails{
                 .toList();
     }
 
-    /**
-     * Constructor por defecto requerido por JPA.
-     */
-    public User() {
-    }
+    public User() {}
 
     /**
      * Construye un nuevo usuario con nombre, email, contraseña, rol y rango es opcional.
@@ -120,6 +116,6 @@ public class User implements UserDetails{
         this.password = password;
         this.role = role;
         this.rank = rank;
-        this.points = 0;
+        this.points = 0; 
     }
 }

--- a/src/main/java/com/equipo2/bytestournament/repository/UserRepository.java
+++ b/src/main/java/com/equipo2/bytestournament/repository/UserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import com.equipo2.bytestournament.model.User;
  
 @Repository
-public interface UserRepository extends JpaRepository  <User, Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
 
     /**
      * Busca un usuario por su nombre de usuario.

--- a/src/main/java/com/equipo2/bytestournament/service/MatchService.java
+++ b/src/main/java/com/equipo2/bytestournament/service/MatchService.java
@@ -1,0 +1,181 @@
+package com.equipo2.bytestournament.service;
+
+import com.equipo2.bytestournament.DTO.MatchDTO;
+import com.equipo2.bytestournament.enums.ApiResponse;
+import com.equipo2.bytestournament.enums.Result;
+import com.equipo2.bytestournament.exceptions.RequestException;
+import com.equipo2.bytestournament.mapper.MatchMapper;
+import com.equipo2.bytestournament.model.Match;
+import com.equipo2.bytestournament.model.Tournament;
+import com.equipo2.bytestournament.model.User;
+import com.equipo2.bytestournament.repository.MatchRepository;
+import com.equipo2.bytestournament.repository.TournamentRepository;
+import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static com.equipo2.bytestournament.model.Match.UMBRAL;
+
+@Service
+public class MatchService {
+    private final MatchRepository matchRepository;
+    private final MatchMapper matchMapper;
+    private final TournamentRepository tournamentRepository;
+    public final Logger logger = Logger.getLogger(MatchService.class.getName());
+
+    public MatchService(MatchRepository matchRepository, MatchMapper matchMapper, TournamentRepository tournamentRepository) {
+        this.matchRepository = matchRepository;
+        this.matchMapper = matchMapper;
+        this.tournamentRepository = tournamentRepository;
+    }
+
+    /**
+     * Genera los matches para un torneo especifico.
+     * Se emparejan los jugadores de forma aleatoria, teniendo en cuenta que la diferencia de puntos entre ellos no supere el umbral.
+     * Si no hay suficientes jugadores, se lanza una excepción.
+     * Si el torneo no existe, se lanza una excepción.
+     * Si se generan los matches correctamente, se devuelve una lista de MatchDTO con los matches generados.
+     * 
+     * @param tournamentID
+     * @return
+     */
+    public List<MatchDTO> generateMatches(Long tournamentID) {
+        try{
+            // Obtenemos el torneo que le estamos pasando
+            Optional<Tournament> tournamentOptional = tournamentRepository.findById(tournamentID);
+
+            if (tournamentOptional.isEmpty())
+                throw new RequestException(ApiResponse.NOT_FOUND, "No se ha encontrado el torneo", "El torneo con id " + tournamentID + " no existe");
+
+            Tournament tournament = tournamentOptional.get();
+            logger.info("Generando matches para el torneo: " + tournament.getName());
+
+            // Obtenemos la lista de jugadores del torneo
+            List<User> players = tournament.getPlayers();
+            if (players.size() < 2)
+                throw new RequestException(ApiResponse.UNPROCESSABLE_ENTITY);
+
+            // Actualizamos la ronda del torneo
+            tournament.setRounds(tournament.getRounds() + 1);
+
+            // Copiamos los jugadores para la logica de emparejamiento y no modificar la lista original
+            List<User> emparejatedPlayers = new ArrayList<>(players);
+            // Genemamos todos los matches de la ronda actual
+            while (emparejatedPlayers.size() >= 2) {
+                List<User> emparejatedMatch = this.matchUsers(emparejatedPlayers);
+
+                // Obtenemos los dos jugadores emparejados
+                User player1 = emparejatedMatch.get(0);
+                User player2 = emparejatedMatch.get(1);
+
+                // Eliminamos los jugadores de la lista de emparejamiento
+                Match newMatch = Match.builder()
+                        .tournament(tournament)
+                        .player1(player1)
+                        .player2(player2)
+                        .result(Result.PENDING)
+                        .round(tournament.getRounds())
+                        .build();
+
+                // Añadimos un nuevo match a la lista de matches del torneo
+                List<Match> tournamentList = tournament.getMatches();
+                tournamentList.add(newMatch);
+
+                // Añadimos el match a la base de datos
+                matchRepository.save(newMatch);
+                logger.info("Match generado: " + player1.getEmail() + " vs " + player2.getEmail());
+            }
+
+            // Guardamos los cambios del torneo
+            tournamentRepository.save(tournament);
+            logger.info("Matches generados para el torneo: " + tournament.getName());
+
+            return matchMapper.matchListToMatchDTOList(tournament.getMatches());
+        } catch (RequestException error){
+            throw error;
+        } catch (Exception error) {
+            throw new RequestException(ApiResponse.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Empareja dos jugadores de forma aleatoria, teniendo en cuenta que la diferencia de puntos entre ellos no supere el umbral.
+     * Si no hay suficientes jugadores, se lanza una excepción.
+     * Si no hay jugadores que cumplan el criterio de puntos, se lanza una excepción.
+     * 
+     * @param allPlayers
+     * @return
+     */
+    public List<User> matchUsers(List<User> allPlayers) {
+        // Comprobamos que haya al menos 2 jugadores para emparejar
+        if(allPlayers.size() < 2)
+            throw new RequestException(ApiResponse.UNPROCESSABLE_ENTITY);
+
+        // Obtenemos el jugador 1 de forma aleatoria
+        User player1 = allPlayers.get((int) (Math.random() * allPlayers.size()));
+        allPlayers.remove(player1);
+
+        // Filtramos por todos los jugadores que tengan menos o mas de 100 puntos de diferencia
+        List<User> players = allPlayers.stream()
+                .filter(player -> Math.abs(player.getPoints() - player1.getPoints()) <= UMBRAL)
+                .toList();
+
+        // Obtenemos el jugador 2 de forma aleatoria
+        User player2 = players.get((int) (Math.random() * players.size()));
+        allPlayers.remove(player2);
+
+        return List.of(player1, player2);
+    }
+
+    /**
+     * Comprueba si un match existe en la base de datos.
+     * Si el match no existe, lanza una excepción.
+     * Si el match existe, devuelve un mensaje informativo con los jugadores del match.
+     * 
+     * @param id
+     */
+    public MatchDTO checkMatch(Long id) {
+        // Comprobamos si el match existe
+        Optional<Match> matchOptional = matchRepository.findById(id);
+        if (matchOptional.isEmpty())
+            throw new RequestException(ApiResponse.NOT_FOUND, "No se ha encontrado el match", "El match con id " + id + " no existe");
+
+        Match match = matchOptional.get();
+        logger.info("Match encontrado: " + match.getPlayer1().getEmail() + " vs " + match.getPlayer2().getEmail());
+        
+        return matchMapper.matchToMatchDTO(match);
+    }
+
+    /**
+     * Actualiza el resultado de un match.
+     * Si el match no existe, lanza una excepción.
+     * Si el resultado es PENDING, lanza una excepción.
+     * Si el resultado es WIN o LOSE, actualiza el resultado del match y devuelve un mensaje informativo.
+     * 
+     * @param id
+     * @return
+     */
+    public MatchDTO updateMatchResult(Long id, MatchDTO macthDTO) {
+        // Comprobamos si el match existe
+        Optional<Match> matchOptional = matchRepository.findById(id);
+        if (matchOptional.isEmpty())
+            throw new RequestException(ApiResponse.NOT_FOUND, "No se ha encontrado el match", "El match con id " + id + " no existe");
+
+        Match match = matchOptional.get();
+
+        // Comprobamos que el id proiporcionado sea el mismo que elq ue queremos actualizar
+        if (!match.getId().equals(id))
+            throw new RequestException(ApiResponse.UNPROCESSABLE_ENTITY, "El id del match no coincide", "El id del match proporcionado no coincide con el id del match a actualizar");
+
+        // Actualizamos el resultado del match
+        Match matchUpdated = matchMapper.matchDtoToMatch(macthDTO);
+        matchUpdated.setId(id);
+
+        matchRepository.save(matchUpdated);
+        logger.info("Resultado del match actualizado: " + matchUpdated.getPlayer1().getEmail() + " vs " + matchUpdated.getPlayer2().getEmail());
+
+        return matchMapper.matchToMatchDTO(matchUpdated);
+    }
+}

--- a/src/main/java/com/equipo2/bytestournament/service/MatchService.java
+++ b/src/main/java/com/equipo2/bytestournament/service/MatchService.java
@@ -111,7 +111,8 @@ public class MatchService {
     public List<User> matchUsers(List<User> allPlayers) {
         // Comprobamos que haya al menos 2 jugadores para emparejar
         if(allPlayers.size() < 2)
-            throw new RequestException(ApiResponse.UNPROCESSABLE_ENTITY);
+            throw new RequestException(ApiResponse.UNPROCESSABLE_ENTITY, "Entidad No Procesable",
+            "La solicitud contiene datos que no se pueden procesar debido a que se necesitan al menos 2 jugadores para emparejar");
 
         // Obtenemos el jugador 1 de forma aleatoria
         User player1 = allPlayers.get((int) (Math.random() * allPlayers.size()));

--- a/src/main/java/com/equipo2/bytestournament/service/TournamentService.java
+++ b/src/main/java/com/equipo2/bytestournament/service/TournamentService.java
@@ -1,0 +1,77 @@
+package com.equipo2.bytestournament.service;
+
+import com.equipo2.bytestournament.DTO.TournamentDTO;
+import com.equipo2.bytestournament.enums.ApiResponse;
+import com.equipo2.bytestournament.exceptions.RequestException;
+import com.equipo2.bytestournament.mapper.TournamentMapper;
+import com.equipo2.bytestournament.model.Tournament;
+import com.equipo2.bytestournament.model.User;
+import com.equipo2.bytestournament.repository.TournamentRepository;
+import com.equipo2.bytestournament.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Service
+public class TournamentService {
+    private final TournamentRepository tournamentRepository;
+    private final TournamentMapper tournamentMapper;
+    private final UserRepository userRepository;
+    private final Logger logger = LoggerFactory.getLogger(UserService.class);
+
+    public TournamentService(TournamentRepository tournamentRepository, TournamentMapper tournamentMapper, UserRepository userRepository) {
+        this.tournamentRepository = tournamentRepository;
+        this.tournamentMapper = tournamentMapper;
+        this.userRepository = userRepository;
+    }
+
+    public TournamentDTO findTournamentById(Long id){
+        Optional<Tournament> tournamentOptional = tournamentRepository.findById(id);
+
+        if(!tournamentOptional.isPresent())
+            throw new RequestException(ApiResponse.NOT_FOUND, "Tournament no encontrado", "No se encontro un tournament con esa ID");
+
+        Tournament tournament = tournamentOptional.get();
+        return tournamentMapper.tournamentToTournamentDTO(tournament);
+    }
+
+    public TournamentDTO createTournament(TournamentDTO entity) {
+        // Aquí se debería implementar la lógica para crear un torneo a partir de la entidad proporcionada
+        // Por ahora, simplemente retornamos un TournamentDTO vacío como ejemplo
+        Tournament tournament = tournamentMapper.tournamentDtoToTournament(entity);
+        // Aquí se deberían establecer los valores del torneo según la entidad recibida
+        tournamentRepository.save(tournament);
+        return tournamentMapper.tournamentToTournamentDTO(tournament);
+    }
+
+    public TournamentDTO addPlayerToTournament(Long tournamentId, String userName) {
+        // Validamos si existe el torneo y el usuario
+        Optional<Tournament> tournamentOptional = tournamentRepository.findById(tournamentId);
+
+        if(tournamentOptional.isEmpty()) 
+            throw new RequestException(ApiResponse.NOT_FOUND, "Tournament no encontrado", "No se encontro un torneo con esa ID");
+
+        Optional<User> userOptional = userRepository.findByUsername(userName);
+
+        if(userOptional.isEmpty()) 
+            throw new RequestException(ApiResponse.NOT_FOUND, "Usuario no encontrado", "No se encontro un usuario con esa ID");
+        
+        // Añadmios las referencias del usuario al torneo viceversa
+        User user = userOptional.get();
+        Tournament tournament = tournamentOptional.get();
+
+        // En el torneo hay un nuevo usuario
+        tournament.getPlayers().add(userOptional.get());
+        // Un nuevo usuaurio pertenece a un torneo
+        user.getTournaments().add(tournamentOptional.get());
+
+        // Guardamos en la base de datos todos los cambios
+        Tournament torurnamentSaved = tournamentRepository.save(tournament);
+        userRepository.save(user);
+
+        logger.info("Usuario {} se ha unido al torneo {}", user.getEmail(), tournament.getName());
+
+        return tournamentMapper.tournamentToTournamentDTO(torurnamentSaved);
+    }
+}

--- a/src/main/java/com/equipo2/bytestournament/service/UserService.java
+++ b/src/main/java/com/equipo2/bytestournament/service/UserService.java
@@ -1,7 +1,8 @@
 package com.equipo2.bytestournament.service;
 
 import java.util.Optional;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,6 +23,7 @@ public class UserService {
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
+    private final Logger logger = LoggerFactory.getLogger(UserService.class);
     
     public UserService(AuthenticationManager authenticationManager, UserRepository userRepository, UserMapper userMapper, JwtUtil jwtUtil, PasswordEncoder passwordEncoder) {
         this.authenticationManager = authenticationManager;
@@ -34,13 +36,12 @@ public class UserService {
 
     public String registerUser(UserDTO userDTO){
         try {
-             // UserDTO -> User
+            // UserDTO -> User
             User user = userMapper.userDTOToUser(userDTO);
-
-
+            
             // Ciframos la contraseña
             user.setPassword(passwordEncoder.encode(user.getPassword()));
-            
+            logger.info("Password encoded for user: " + user.getEmail());
 
             // Guardar en la base de datos el User
             User newUser = userRepository.save(user);
@@ -59,7 +60,7 @@ public class UserService {
             return jwtUtil.generateToken(authentication);
         } catch (Exception e) {
              // Si las credenciales son inválidas o hay otro problema
-            throw new RequestException(ApiResponse.AUTHENTICATION_FAILED);
+            throw new RequestException(ApiResponse.INTERNAL_SERVER_ERROR);
         }
        
     }

--- a/src/main/java/com/equipo2/bytestournament/service/UserService.java
+++ b/src/main/java/com/equipo2/bytestournament/service/UserService.java
@@ -18,6 +18,7 @@ import com.equipo2.bytestournament.repository.UserRepository;
 
 @Service
 public class UserService {
+
     private final UserRepository userRepository;
     private final UserMapper userMapper;
     private final JwtUtil jwtUtil;
@@ -34,8 +35,15 @@ public class UserService {
     }
 
 
-    public String registerUser(UserDTO userDTO){
+    public String registerUser(UserDTO userDTO) {
         try {
+            Optional<User> userSearch = userRepository.findByUsername(userDTO.getUsername());
+
+            // Si el usuario ya existe, lanzamos una excepción ya que no puede haver registro duplicado
+            if(userSearch.isPresent()) 
+                throw new RequestException(ApiResponse.DUPLICATE_RESOURCE);
+            
+
             // UserDTO -> User
             User user = userMapper.userDTOToUser(userDTO);
             
@@ -58,6 +66,9 @@ public class UserService {
             
             // Generar y devolver JWT 
             return jwtUtil.generateToken(authentication);
+        } catch (RequestException e) {
+            // Si el usuario ya existe o hay otro problema relacionado con la solicitud
+            throw e; // Re-lanzamos la excepción para que sea manejada por el controlador
         } catch (Exception e) {
              // Si las credenciales son inválidas o hay otro problema
             throw new RequestException(ApiResponse.INTERNAL_SERVER_ERROR);

--- a/src/main/resources/Bytes_Tournament.postman_collection.json
+++ b/src/main/resources/Bytes_Tournament.postman_collection.json
@@ -1,22 +1,44 @@
 {
   "info": {
-    "_postman_id": "2b336dbf-1d60-47c0-9f95-0aecf4fb82a4",
+    "_postman_id": "75e3664e-f82d-4a5e-b468-4a47d1822bca",
     "name": "Bytes_Tournament",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "41327597"
+    "_exporter_id": "37428615"
   },
   "item": [
     {
       "name": "User",
       "item": [
         {
-          "name": "Register",
+          "name": "RegisterPlayer1",
           "request": {
             "method": "POST",
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\r\n  \"username\": \"usuario123\",\r\n  \"email\": \"usuario@email.com\",\r\n  \"password\": \"password123\",\r\n  \"role\": \"PLAYER\",\r\n  \"rank\": \"GOLD\",\r\n  \"points\": 1000\r\n}",
+              "raw": "{\r\n  \"username\": \"jorge\",\r\n  \"email\": \"jorge@gmail.com\",\r\n  \"password\": \"jorge20\",\r\n  \"role\": \"ADMIN\",\r\n  \"rank\": \"GOLD\",\r\n  \"points\": 1000\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/auth/register",
+              "host": ["{{base_url}}"],
+              "path": ["api", "auth", "register"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "RegisterPlayer2",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"username\": \"chanti\",\r\n  \"email\": \"chanti@gmail.com\",\r\n  \"password\": \"chanti20\",\r\n  \"role\": \"ADMIN\",\r\n  \"rank\": \"GOLD\",\r\n  \"points\": 1000\r\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -41,7 +63,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\r\n  \"username\": \"usuario123\",\r\n  \"email\": \"usuario@email.com\",\r\n  \"password\": \"password123\",\r\n  \"role\": \"PLAYER\",\r\n  \"rank\": \"GOLD\",\r\n  \"points\": 1000\r\n}",
+              "raw": "{\r\n  \"username\": \"cahnti\",\r\n  \"email\": \"jorge@gmail.com\",\r\n  \"password\": \"jorge20\",\r\n  \"role\": \"ADMIN\",\r\n  \"rank\": \"GOLD\",\r\n  \"points\": 1000\r\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -59,12 +81,22 @@
         {
           "name": "Me",
           "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJqb3JnZUBnbWFpbC5jb20iLCJpYXQiOjE3NTA1MjM1MzIsImV4cCI6MTQ3MTA1MjM1MzJ9.quR1zQwyyM7W5Hi0paBLdNNrxLC9PWn8E8i1SU0q5PFwBvflIJajHp-hxdZoCTkrh_2zqeQvg09S1dSw7m3oxg",
+                  "type": "string"
+                }
+              ]
+            },
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/users/me",
+              "raw": "{{base_url}}/api/user/me",
               "host": ["{{base_url}}"],
-              "path": ["api", "users", "me"]
+              "path": ["api", "user", "me"]
             }
           },
           "response": []
@@ -72,12 +104,22 @@
         {
           "name": "IdUser",
           "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "",
+                  "type": "string"
+                }
+              ]
+            },
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/users/{id}",
+              "raw": "{{base_url}}/api/user/1",
               "host": ["{{base_url}}"],
-              "path": ["api", "users", "{id}"]
+              "path": ["api", "user", "1"]
             }
           },
           "response": []
@@ -90,12 +132,68 @@
         {
           "name": "Create_Tournaments",
           "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "",
+                  "type": "string"
+                }
+              ]
+            },
             "method": "POST",
             "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n  \"name\": \"Torneo de Verano 2025\",\r\n  \"maxPlayers\": 10,\r\n  \"status\": \"CREATED\",\r\n  \"maxRounds\": 10\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
             "url": {
               "raw": "{{base_url}}/api/tournaments",
               "host": ["{{base_url}}"],
               "path": ["api", "tournaments"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Add usert to turnament",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJqb3JnZUBnbWFpbC5jb20iLCJpYXQiOjE3NTA1MjM1MzIsImV4cCI6MTQ3MTA1MjM1MzJ9.quR1zQwyyM7W5Hi0paBLdNNrxLC9PWn8E8i1SU0q5PFwBvflIJajHp-hxdZoCTkrh_2zqeQvg09S1dSw7m3oxg",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": ""
+            },
+            "url": {
+              "raw": "{{base_url}}/api/tournaments/players?tournamentId=1&userName=jorge",
+              "host": ["{{base_url}}"],
+              "path": ["api", "tournaments", "players"],
+              "query": [
+                {
+                  "key": "tournamentId",
+                  "value": "1"
+                },
+                {
+                  "key": "userName",
+                  "value": "jorge"
+                }
+              ]
             }
           },
           "response": []
@@ -162,6 +260,15 @@
           "request": {
             "method": "POST",
             "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
             "url": {
               "raw": "{{base_url}}/api/tournaments/{id}/messages",
               "host": ["{{base_url}}"],
@@ -241,6 +348,105 @@
               "raw": "{{base_url}}/api/tournaments/{id}/messages",
               "host": ["{{base_url}}"],
               "path": ["api", "tournaments", "{id}", "messages"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Matches",
+      "item": [
+        {
+          "name": "Create match",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/matches/generate/1",
+              "host": ["{{base_url}}"],
+              "path": ["api", "matches", "generate", "1"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Check Match",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/matches/1",
+              "host": ["{{base_url}}"],
+              "path": ["api", "matches", "1"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Match",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n    \"id\": 1,\r\n    \"tournament\": 1,\r\n    \"player1\": 1,\r\n    \"player2\": 2,\r\n    \"result\": \"PLAYER1_WIN\",\r\n    \"round\": 5\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/matches/1/result",
+              "host": ["{{base_url}}"],
+              "path": ["api", "matches", "1", "result"],
+              "query": [
+                {
+                  "key": "id",
+                  "value": "1",
+                  "disabled": true
+                }
+              ]
             }
           },
           "response": []

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,9 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 # Configuracion JWT
 spring.jpa.show-sql=true
 springdoc.swagger-ui.path=/swagger-ui.html
+
+# Nivel de log general para tu aplicación
+logging.level.com.equipo2.bytestournament=INFO
+
+# Habilitar colores ANSI
+spring.output.ansi.enabled=always

--- a/src/main/resources/tournament_db.sql
+++ b/src/main/resources/tournament_db.sql
@@ -33,11 +33,11 @@ SET default_table_access_method = heap;
 --
 
 CREATE TABLE public.matches (
-    id BIGINT NOT NULL,
+    id BIGSERIAL NOT NULL,
     tournament_id BIGINT NOT NULL,
     player1_id BIGINT,
     player2_id BIGINT,
-    result varchar(20) check (result IN ('PLAYER1_WIN', 'PLAYER2_WIN', 'DRAW', 'IN_PROGRESS')) NOT NULL,
+    result varchar(20) check (result IN ('PLAYER1_WIN', 'PLAYER2_WIN', 'DRAW', 'PENDING')) NOT NULL,
     round integer NOT NULL
 );
 
@@ -50,7 +50,7 @@ ALTER TABLE public.matches OWNER TO postgres;
 --
 
 CREATE TABLE public.messages (
-    id BIGINT NOT NULL,
+    id BIGSERIAL NOT NULL,
     sender_id BIGINT NOT NULL,
     content text NOT NULL,
     "timestamp" timestamp with time zone NOT NULL,
@@ -71,8 +71,8 @@ CREATE TABLE public.tournament_players (
     user_id BIGINT NOT NULL
 );
 
-
 ALTER TABLE public.tournament_players OWNER TO postgres;
+
 
 --
 -- TOC entry 218 (class 1259 OID 16415)
@@ -80,10 +80,12 @@ ALTER TABLE public.tournament_players OWNER TO postgres;
 --
 
 CREATE TABLE public.tournaments (
-    id BIGINT NOT NULL,
+    id BIGSERIAL NOT NULL,
     name character varying(100) NOT NULL,
     max_players integer NOT NULL,
-    status varchar(20) check (status IN ('PENDING', 'ONGOING', 'FINISHED')) NOT NULL
+    status varchar(20) check (status IN ('PENDING', 'IN_PROGRESS', 'FINISHED')) NOT NULL,
+    rounds integer NOT NULL DEFAULT 0,
+    max_rounds integer NOT NULL DEFAULT 0
 );
 
 
@@ -97,10 +99,10 @@ ALTER TABLE public.tournaments OWNER TO postgres;
 CREATE TABLE public.users (
     id BIGSERIAL PRIMARY KEY NOT NULL,
     username character varying(50) NOT NULL unique,
-    password character varying(255) NOT NULL,
     email character varying(100) NOT NULL unique,
-    rank character varying(50) NOT NULL,
+    password character varying(255) NOT NULL,
     role varchar(20) check (role IN ('ADMIN', 'PLAYER')) NOT NULL DEFAULT 'PLAYER',
+    rank character varying(50) NOT NULL,
     points integer NOT NULL
 );
 
@@ -152,7 +154,7 @@ COPY public.tournament_players (tournament_id, user_id) FROM stdin;
 -- Data for Name: tournaments; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.tournaments (id, name, max_players, status) FROM stdin;
+COPY public.tournaments (id, name, max_players, status, rounds, max_rounds) FROM stdin;
 \.
 
 
@@ -289,10 +291,7 @@ ALTER TABLE ONLY public.tournament_players
 --
 
 ALTER TABLE ONLY public.tournament_players
-    ADD CONSTRAINT user_id FOREIGN KEY (user_id) REFERENCES public.users(id);
-
-
--- Completed on 2025-06-19 16:02:47
+    ADD CONSTRAINT user_id FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 --
 -- PostgreSQL database dump complete

--- a/src/test/java/com/equipo2/bytestournament/mapper/UserMapper.java
+++ b/src/test/java/com/equipo2/bytestournament/mapper/UserMapper.java
@@ -15,7 +15,11 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class UserMapperTest {
 
-    private final UserMapper userMapper = new UserMapper();
+    private final UserMapper userMapper;
+
+    public UserMapperTest(UserMapper userMapper) {
+        this.userMapper = userMapper;
+    }
 
     /**
      * Test para verificar la conversión de User a UserDTO y viceversa.
@@ -65,7 +69,7 @@ class UserMapperTest {
                 .points(100)
                 .build();
 
-        User user = userMapper.userDTOToUser(userDTO);
+        User user = userMapper.userDtoToUser(userDTO);
 
         // Verificamos que el User no sea nulo y que los valores coincidan con el UserDTO original, a excecpción del ID
         // porque se genera automáticamente al guardar en la base de datos.

--- a/src/test/java/com/equipo2/bytestournament/mapper/UserMapperTest.java
+++ b/src/test/java/com/equipo2/bytestournament/mapper/UserMapperTest.java
@@ -3,9 +3,15 @@ package com.equipo2.bytestournament.mapper;
 import com.equipo2.bytestournament.DTO.UserDTO;
 import com.equipo2.bytestournament.enums.Rank;
 import com.equipo2.bytestournament.enums.Role;
+import com.equipo2.bytestournament.mapper.helper.UserMapperHelper;
 import com.equipo2.bytestournament.model.User;
+import com.equipo2.bytestournament.repository.TournamentRepository;
 import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 import static org.junit.jupiter.api.Assertions.*;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
 
 /**
  * Clase de prueba para UserMapper.
@@ -15,11 +21,22 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class UserMapperTest {
 
-    private final UserMapper userMapper;
+     private UserMapper userMapper;
 
-    public UserMapperTest(UserMapper userMapper) {
-        this.userMapper = userMapper;
+    @BeforeEach
+    void setUp() {
+        try {
+            userMapper = Mappers.getMapper(UserMapper.class);
+            TournamentRepository tournamentRepository = Mockito.mock(TournamentRepository.class);
+            UserMapperHelper helper = new UserMapperHelper(tournamentRepository);
+            Field helperField = userMapper.getClass().getDeclaredField("userMapperHelper");
+            helperField.setAccessible(true);
+            helperField.set(userMapper, helper);
+        } catch (Exception e) {
+            throw new RuntimeException("Error al inyectar el helper en el mapper para los tests", e);
+        }
     }
+
 
     /**
      * Test para verificar la conversión de User a UserDTO y viceversa.
@@ -29,7 +46,7 @@ class UserMapperTest {
     @Test
     void testUserToUserDTO() {
         User user = User.builder()
-                .id(1L)
+                .id(1L)// Ejemplo de id de la DB
                 .username("testUserMapper")
                 .email("testmapper@gmail.com")
                 .password("1234")
@@ -60,7 +77,7 @@ class UserMapperTest {
     @Test
     void testUserDTOToUser() {
         UserDTO userDTO = UserDTO.builder()
-                .id(1L)
+                .id(1L) // Ejemplo de ID que proporciono el User
                 .username("testUserMapper")
                 .email("testmapper@gmail.com")
                 .password("1234")
@@ -69,13 +86,13 @@ class UserMapperTest {
                 .points(100)
                 .build();
 
-        User user = userMapper.userDtoToUser(userDTO);
+        User user = userMapper.userDTOToUser(userDTO);
 
         // Verificamos que el User no sea nulo y que los valores coincidan con el UserDTO original, a excecpción del ID
         // porque se genera automáticamente al guardar en la base de datos.
         assertNotNull(user);
-        assertNull(user.getId());
         assertAll(
+                () -> assertEquals(userDTO.getId(), user.getId()),
                 () -> assertEquals(userDTO.getEmail(), user.getEmail()),
                 () -> assertEquals(userDTO.getUsername(), user.getUsername()),
                 () -> assertEquals(userDTO.getRole(), user.getRole()),

--- a/src/test/java/com/equipo2/bytestournament/service/UserServiceTest.java
+++ b/src/test/java/com/equipo2/bytestournament/service/UserServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import com.equipo2.bytestournament.enums.Role;
 import org.springframework.security.core.Authentication;
-
 import java.util.Optional;
 
 /**


### PR DESCRIPTION
- Enpoints
/api/matches/generate/{tournamentId}  // Para generar un match entre dos jugadores en un torneo
/api/matches/{id} // Para acceder a un match
/api/matches/{id}/result // Para actualizar un match

- Entidades
Se hicieron algunas mejoras para los entidades como relaciones entre entidades mejoradas o algunos campos a mayores de los que ya habían.

- Mappers
Se mejoror los mappers con mappers helpers para poder mapear los cambios de relación, por ejemplo List<Tournament> -> List<Long> que representa una lista de IDs de torneos, entre otros.